### PR TITLE
Update Kruise-manager components docs from statefulset to deployment

### DIFF
--- a/docs/en-us/components.md
+++ b/docs/en-us/components.md
@@ -22,32 +22,32 @@ uniteddeployments.apps.kruise.io              2020-06-15T12:00:05Z
 
 ## Kruise-manager
 
-Kruise-manager is a control plane component that runs controllers and webhooks, it is deployed by a StatefulSet in `kruise-system` namespace.
+Kruise-manager is a control plane component that runs controllers and webhooks, it is deployed by a Deployment in `kruise-system` namespace.
 
 ```shell
-$ kubectl get sts -n kruise-system
-NAME                        READY   AGE
-kruise-controller-manager   1/1     11m
+$ kubectl get deploy -n kruise-system
+NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
+kruise-controller-manager   2/2     2            2           11m
 
 $ kubectl get pod -n kruise-system
-NAME                          READY   STATUS    RESTARTS   AGE
-kruise-controller-manager-0   1/1     Running   1          11m
+NAME                                         READY   STATUS    RESTARTS   AGE
+kruise-controller-manager-78b98899c6-f8t67   1/1     Running   0          11m
+kruise-controller-manager-78b98899c6-tjlxl   1/1     Running   0          11m
 ```
 
-<!-- It can be deployed as multiple replicas with StatefulSet, but only one of them could become leader and start working, others will keep retrying to acquire the lock. -->
+<!-- It can be deployed as multiple replicas with Deployment, but only one of them could become leader and start working, others will keep retrying to acquire the lock. -->
 
-Logically, each controller like cloneset-controller or sidecarset-controller is a separate process, but to reduce complexity, they are all compiled into a single binary and run in the `kruise-controller-manager-0` single Pod.
+Logically, each controller like cloneset-controller or sidecarset-controller is a separate process, but to reduce complexity, they are all compiled into a single binary and run in the `kruise-controller-manager-xxx` single Pod.
 
 Besides controllers, this Pod also contains the admission webhooks for Kruise CRDs and Pod. It creates webhook configurations to configure which resources should be handled, and provides a Service for kube-apiserver calling.
 
 ```shell
 $ kubectl get svc -n kruise-system
 NAME                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
-kruise-controller-manager-service   ClusterIP   10.106.157.122   <none>        443/TCP   13m
 kruise-webhook-server-service       ClusterIP   10.109.43.220    <none>        443/TCP   12m
 ```
 
-The `kruise-controller-manager-service` is useless, but `kruise-webhook-server-service` is much important for kube-apiserver calling.
+The `kruise-webhook-server-service` is much important for kube-apiserver calling.
 
 ## Kruise-daemon
 

--- a/docs/zh-cn/components.md
+++ b/docs/zh-cn/components.md
@@ -22,32 +22,32 @@ uniteddeployments.apps.kruise.io              2020-06-15T12:00:05Z
 
 ## Kruise-manager
 
-Kruise-manager 是一个运行 controller 和 webhook 中心组件，它通过 StatefulSet 部署在 `kruise-system` 命名空间中。
+Kruise-manager 是一个运行 controller 和 webhook 中心组件，它通过 Deployment 部署在 `kruise-system` 命名空间中。
 
 ```shell
-$ kubectl get sts -n kruise-system
-NAME                        READY   AGE
-kruise-controller-manager   1/1     11m
+$ kubectl get deploy -n kruise-system
+NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
+kruise-controller-manager   2/2     2            2           11m
 
 $ kubectl get pod -n kruise-system
-NAME                          READY   STATUS    RESTARTS   AGE
-kruise-controller-manager-0   1/1     Running   1          11m
+NAME                                         READY   STATUS    RESTARTS   AGE
+kruise-controller-manager-78b98899c6-f8t67   1/1     Running   0          11m
+kruise-controller-manager-78b98899c6-tjlxl   1/1     Running   0          11m
 ```
 
-<!-- It can be deployed as multiple replicas with StatefulSet, but only one of them could become leader and start working, others will keep retrying to acquire the lock. -->
+<!-- It can be deployed as multiple replicas with Deployment, but only one of them could become leader and start working, others will keep retrying to acquire the lock. -->
 
-逻辑上来说，如 cloneset-controller/sidecarset-controller 这些的 controller 都是独立运行的。不过为了减少复杂度，它们都被打包在一个独立的二进制文件、并运行在 `kruise-controller-manager-0` 这个 Pod 中。
+逻辑上来说，如 cloneset-controller/sidecarset-controller 这些的 controller 都是独立运行的。不过为了减少复杂度，它们都被打包在一个独立的二进制文件、并运行在 `kruise-controller-manager-xxx` 这个 Pod 中。
 
-除了 controller 之外，`kruise-controller-manager-0` 中还包含了针对 Kruise CRD 以及 Pod 资源的 admission webhook。Kruise-manager 会创建一些 webhook configurations 来配置哪些资源需要感知处理、以及提供一个 Service 来给 kube-apiserver 调用。
+除了 controller 之外，`kruise-controller-manager-xxx` 中还包含了针对 Kruise CRD 以及 Pod 资源的 admission webhook。Kruise-manager 会创建一些 webhook configurations 来配置哪些资源需要感知处理、以及提供一个 Service 来给 kube-apiserver 调用。
 
 ```shell
 $ kubectl get svc -n kruise-system
 NAME                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
-kruise-controller-manager-service   ClusterIP   10.106.157.122   <none>        443/TCP   13m
 kruise-webhook-server-service       ClusterIP   10.109.43.220    <none>        443/TCP   12m
 ```
 
-上述的 `kruise-controller-manager-service` 是没用的，但是 `kruise-webhook-server-service` 非常重要，是提供给 kube-apiserver 调用的。
+上述的 `kruise-webhook-server-service` 非常重要，是提供给 kube-apiserver 调用的。
 
 ## Kruise-daemon
 


### PR DESCRIPTION
Fix https://github.com/openkruise/kruise/issues/379

In the openkruise version v0.6.0, the Kruise-manager component has been updated from statefulset to deployment, and the service `kruise-controller-manager-service` also has been removed, we should update the document synchronously.